### PR TITLE
feat: TET-660 fix width button issue

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -157,3 +157,12 @@ export const BareDisabled: Story = {
     variant: 'bare',
   },
 };
+
+// should automatically fill the width of the container
+export const WithFlexContainer: Story = {
+  render: () => (
+    <div style={{ display: 'flex', width: '400px', flexDirection: 'column' }}>
+      <Button label="Button 1" />
+    </div>
+  ),
+};

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -287,7 +287,7 @@ const commonConfig = {
   display: 'inline-flex',
   borderRadius: '$border-radius-large',
   gap: '$space-component-gap-small',
-  w: 'fit-content',
+  w: 'auto',
   justifyContent: 'center',
   alignItems: 'center',
   textAlign: 'center',

--- a/src/components/Button/stylesBuilder/stylesBuilder.test.ts
+++ b/src/components/Button/stylesBuilder/stylesBuilder.test.ts
@@ -54,7 +54,7 @@ describe('stylesBuilder', () => {
         textAlign: 'center',
         transition: true,
         transitionDuration: 200,
-        w: 'fit-content',
+        w: 'auto',
         whiteSpace: 'nowrap',
       },
       loader: {


### PR DESCRIPTION
## What did you implement?

changed button width from `fit-content` to `auto` and create Story with col flex wrapper

## Checklist:

- [ ] ~~I exported my component in [src/index.ts](https://github.com/VirtusLab/tetrisly-react/blob/main/src/index.ts) file.~~
- [ ] ~~I described colors, spacing, typography, and similar attributes with Figma Tokens and they are placed in the config object in the `*.styles` file~~
- [ ] ~~I tested the component (including custom prop)~~
- [x] I've written a storybook story for the component
